### PR TITLE
Fix mini bosses potentially attacking before their start time

### DIFF
--- a/osu.Game.Rulesets.Rush.Tests/TestSceneMiniBoss.cs
+++ b/osu.Game.Rulesets.Rush.Tests/TestSceneMiniBoss.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Rush.Beatmaps;
+using osu.Game.Rulesets.Rush.Objects;
+using osu.Game.Rulesets.Rush.UI;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Rush.Tests
+{
+    public class TestSceneMiniBoss : PlayerTestScene
+    {
+        private const float mini_boss_time = 600f;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
+        {
+            var beatmap = new RushBeatmap();
+
+            for (int i = 0; i < mini_boss_time / 200f; i++)
+            {
+                beatmap.HitObjects.Add(new Minion
+                {
+                    StartTime = i * 200,
+                });
+            }
+
+            beatmap.HitObjects.Add(new MiniBoss
+            {
+                StartTime = mini_boss_time,
+                Duration = 1000f,
+            });
+
+            return beatmap;
+        }
+
+        private PlayerTargetLane targetLane => ((DrawableRushRuleset)Player.DrawableRuleset).Playfield.PlayerSprite.Target;
+
+        public TestSceneMiniBoss()
+            : base(new RushRuleset())
+        {
+        }
+
+        [Test]
+        public void TestPlayerStateTransitionsAtCorrectTime()
+        {
+            AddStep("mash air actions", () => Scheduler.AddDelayed(() =>
+            {
+                InputManager.Click(MouseButton.Left);
+            }, 50f, true));
+
+            AddAssert("not in fight state", () => targetLane != PlayerTargetLane.MiniBoss);
+            AddUntilStep("wait for fight state", () => targetLane == PlayerTargetLane.MiniBoss);
+            AddAssert("time has reached mini-boss time", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= mini_boss_time);
+
+            AddStep("stop mashing", () => Scheduler.CancelDelayedTasks());
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
-            if (AllJudged)
+            if (Time.Current < HitObject.StartTime || AllJudged)
                 return;
 
             if (userTriggered && timeOffset < 0)


### PR DESCRIPTION
Probably missed case from https://github.com/swoolcock/rush/commit/3d22a77607e5026e9d8adf50118e9d62907bfa3d

Added a test case for making sure we potentially never hit this again. (and to start writing test scenes for each object :P)