### PR TITLE
Fix jumping and various other visual glitches

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             gearSpriteIcon.Colour = colour.Lighten(0.5f);
         }
 
-        public void UpdateResult() => base.UpdateResult(true);
+        public new bool UpdateResult(bool userTriggered) => base.UpdateResult(userTriggered);
 
         public override bool OnPressed(RushAction action) => false;
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheet.cs
@@ -68,7 +68,14 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             });
 
             AccentColour.ValueChanged += _ => updateHoldStar();
-            HasBroken.ValueChanged += _ => updateHoldStar();
+
+            HasBroken.ValueChanged += _ =>
+            {
+                if (HasBroken.Value && HoldStartTime != null && HoldEndTime == null)
+                    HoldEndTime = Time.Current;
+
+                updateHoldStar();
+            };
         }
 
         private void updateHoldStar() => holdStar.UpdateColour(HasBroken.Value ? Color4.Gray : AccentColour.Value);
@@ -195,7 +202,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
             pressCount--;
 
-            if (pressCount > 0 || AllJudged)
+            if (pressCount > 0)
                 return;
 
             if (HasBroken.Value || HoldStartTime == null || HoldEndTime != null)
@@ -219,7 +226,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             base.Update();
 
-            if (Head.IsHit || HasBroken.Value)
+            if (Head.IsHit && !Tail.AllJudged || HasBroken.Value)
                 holdStar.Show();
             else
                 holdStar.Hide();

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheet.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (AllJudged || timeOffset < 0)
                 return;
 
-            Tail.UpdateResult();
+            Tail.UpdateResult(userTriggered);
 
             if (Tail.IsHit && Head.IsHit && !HasBroken.Value)
                 ApplyResult(r => r.Type = HitResult.Perfect);
@@ -167,15 +167,17 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (!LaneMatchesAction(action))
                 return false;
 
-            pressCount++;
-
             if (pressCount > 1)
                 return true;
 
-            beginHoldAt(Time.Current - Head.HitObject.StartTime);
-            Head.UpdateResult();
+            if (Head.UpdateResult(true))
+            {
+                pressCount++;
+                beginHoldAt(Time.Current - Head.HitObject.StartTime);
+                return true;
+            }
 
-            return true;
+            return false;
         }
 
         private void beginHoldAt(double timeOffset)
@@ -208,7 +210,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                 HasBroken.Value = true;
             else if (Tail.HitObject.HitWindows.CanBeHit(tailOffset))
             {
-                Tail.UpdateResult();
+                Tail.UpdateResult(true);
                 HasBroken.Value = !Tail.IsHit;
             }
         }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetCap.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             Alpha = 1f;
         }
 
-        public void UpdateResult() => base.UpdateResult(true);
+        public new bool UpdateResult(bool userTriggered) => base.UpdateResult(userTriggered);
 
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
         {

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetCap.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
@@ -56,6 +57,19 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             Scale = Vector2.One;
             Alpha = 1f;
+        }
+
+        protected override void UpdateStateTransforms(ArmedState state)
+        {
+            base.UpdateStateTransforms(state);
+
+            switch (state)
+            {
+                case ArmedState.Hit:
+                case ArmedState.Miss:
+                    Hide();
+                    break;
+            }
         }
 
         public new bool UpdateResult(bool userTriggered) => base.UpdateResult(userTriggered);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetCap.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetCap.cs
@@ -63,13 +63,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             base.UpdateStateTransforms(state);
 
-            switch (state)
-            {
-                case ArmedState.Hit:
-                case ArmedState.Miss:
-                    Hide();
-                    break;
-            }
+            if (state == ArmedState.Hit)
+                Hide();
         }
 
         public new bool UpdateResult(bool userTriggered) => base.UpdateResult(userTriggered);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetTail.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheetTail.cs
@@ -18,17 +18,11 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
-            // Factor in the release lenience
-            timeOffset /= RELEASE_WINDOW_LENIENCE;
-
+            // for now let's give the player an automatic perfect if they hold the note (like in a certain other rhythm game)
             if (!userTriggered)
             {
-                if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                {
-                    ApplyResult(r => r.Type = HitResult.Miss);
-                    HasBroken.Value = true;
-                }
-
+                if (timeOffset >= 0)
+                    ApplyResult(r => r.Type = HasBroken.Value ? HitResult.Miss : HitResult.Perfect);
                 return;
             }
 
@@ -36,7 +30,8 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (result == HitResult.None)
                 return;
 
-            ApplyResult(r => r.Type = HasBroken.Value ? HitResult.Miss : result);
+            // ...and an automatic perfect if they release within any "hit" judged period
+            ApplyResult(r => r.Type = HasBroken.Value ? HitResult.Miss : HitResult.Perfect);
         }
 
         // FIXME: should logically be TrailingAnchor, not sure why it renders incorrectly

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -313,6 +313,30 @@ namespace osu.Game.Rulesets.Rush.UI
 
                     break;
 
+                case Sawblade _:
+                    if (PlayerSprite.CollidesWith(result.HitObject))
+                    {
+                        var damageText = new SpriteText
+                        {
+                            Origin = Anchor.Centre,
+                            Colour = Color4.Red,
+                            Font = FontUsage.Default.With(size: 40),
+                            Scale = new Vector2(1.2f),
+                            Text = $"{healthAmount:D}",
+                            Position = healthPosition,
+                        };
+
+                        overPlayerEffectsContainer.Add(damageText);
+
+                        damageText.ScaleTo(1f, animation_time)
+                                  .Then()
+                                  .FadeOutFromOne(animation_time)
+                                  .MoveToOffset(new Vector2(0f, -20f), animation_time)
+                                  .OnComplete(d => d.Expire());
+                    }
+
+                    break;
+
                 case Heart _ when result.IsHit:
                     var heartFlash = new DrawableHeartIcon
                     {


### PR DESCRIPTION
Ended up being various changes because they all touched similar areas:

* Fixed #20, hopefully.  Essentially made the jumping more lenient so that there's a 20% play height grace area before landing.  Also tweaked the jump/fall speeds to feel a little better.
* Fixed an issue where the dual hit was consuming actions too early and preventing jumps in front of a missed notesheet.
* Fixed an issue where a notesheet hold animation could sometimes be triggered even though the player missed the head.
* Fixed an issue where sawblade damage wasn't displaying.
* Fixed an issue where getting a great on a notesheet tail wouldn't correctly hide the cap.  Note that this actually exacerbates #13, as the player now explicitly gets a perfect if holding past the tail.


@frenzibyte I may self merge this one because I want to get it in a release today.