### PR TITLE
Add initial implementation of the ground display

### DIFF
--- a/osu.Game.Rulesets.Rush.Tests/TestSceneGround.cs
+++ b/osu.Game.Rulesets.Rush.Tests/TestSceneGround.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Rush.UI.Ground;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Rush.Tests
+{
+    public class TestSceneGround : OsuTestScene
+    {
+        public TestSceneGround()
+        {
+            Children = new Drawable[]
+            {
+                new GroundDisplay
+                {
+                    RelativePositionAxes = Axes.Y,
+                    Y = 0.7f,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/DefaultGround.cs
@@ -1,0 +1,103 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Rush.UI.Ground
+{
+    public class DefaultGround : CompositeDrawable
+    {
+        private static readonly Color4 platform_colour = Color4.Gray.Opacity(0.2f);
+
+        private static readonly ColourInfo slat_colour = ColourInfo.GradientVertical(Color4.Gray.Opacity(0.8f), Color4.Gray.Opacity(0.4f));
+        private static readonly Vector2 slat_size = new Vector2(10f, 100f);
+        private const float slat_angle = -40f;
+
+        private const float slats_spacing = 100f;
+
+        private static readonly Color4 ground_colour = Color4.Gray.Opacity(0.2f);
+
+        private readonly FillFlowContainer slatsFlow;
+
+        public DefaultGround()
+        {
+            AutoSizeAxes = Axes.X;
+            RelativeSizeAxes = Axes.Y;
+
+            InternalChild = new FillFlowContainer
+            {
+                AutoSizeAxes = Axes.X,
+                RelativeSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Name = "Top line",
+                        Colour = platform_colour.Opacity(1f).Lighten(1f),
+                        RelativeSizeAxes = Axes.X,
+                        Height = 3f,
+                        Depth = -1,
+                    },
+                    new Container
+                    {
+                        Name = "Platform",
+                        Masking = true,
+                        AutoSizeAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = platform_colour,
+                            },
+                            slatsFlow = new FillFlowContainer
+                            {
+                                AutoSizeAxes = Axes.Both,
+                            },
+                        }
+                    },
+                    new Box
+                    {
+                        Name = "Bottom line",
+                        Colour = platform_colour.Opacity(1f).Lighten(2f),
+                        RelativeSizeAxes = Axes.X,
+                        Height = 3f,
+                    },
+                    new Box
+                    {
+                        Name = "Ground",
+                        Colour = ground_colour,
+                        RelativeSizeAxes = Axes.Both,
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // FIXME: this is hacky but serves its purpose with no impact.
+            // should add required slats on size invalidations from parent.
+            const int maximum_slat_count = 125;
+
+            for (int i = 0; i < maximum_slat_count; i++)
+            {
+                slatsFlow.Add(new Box
+                {
+                    Colour = slat_colour,
+                    Size = slat_size,
+                    Rotation = slat_angle,
+                    Margin = new MarginPadding { Right = slats_spacing, Bottom = -10f },
+                });
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
+++ b/osu.Game.Rulesets.Rush/UI/Ground/GroundDisplay.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Rulesets.Rush.UI.Ground
+{
+    /// <summary>
+    /// Represents a component displaying the ground the player will be standing on.
+    /// </summary>
+    public class GroundDisplay : CompositeDrawable
+    {
+        private const double scroll_speed = 1f;
+
+        private readonly FillFlowContainer groundFlow;
+
+        public GroundDisplay()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChildren = new[]
+            {
+                groundFlow = new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Y,
+                    Direction = FillDirection.Horizontal,
+                    Children = new Drawable[]
+                    {
+                        new DefaultGround { Name = "Leaving-out piece" },
+                        new DefaultGround { Name = "Coming-in piece" },
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ScheduleAfterChildren(() =>
+            {
+                var pieceWidth = groundFlow.Width / 2;
+
+                groundFlow.MoveToX(-pieceWidth, pieceWidth / scroll_speed)
+                          .Then()
+                          .MoveToX(0f)
+                          .Loop(1f);
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Judgements;
 using osu.Game.Rulesets.Rush.Objects;
 using osu.Game.Rulesets.Rush.Objects.Drawables;
+using osu.Game.Rulesets.Rush.UI.Ground;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
@@ -174,9 +175,17 @@ namespace osu.Game.Rulesets.Rush.UI
                                 }
                             },
                         },
-                        new[]
+                        new Drawable[]
                         {
-                            Empty(),
+                            new Container
+                            {
+                                Name = "Ground area",
+                                RelativeSizeAxes = Axes.Both,
+                                // Due to the size of the player sprite, we have to push the ground even more to the bottom.
+                                Padding = new MarginPadding { Top = 50f },
+                                Depth = float.MaxValue,
+                                Child = new GroundDisplay(),
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Adds an initial implementation of the ground display component, compatible for skinning by providing a texture able to be adjacent with itself to perform the *infinite-scrolling* on (but to be hooked later on at skinning stage).

The default ground is currently a placeholder, simple written as an initial implementation:
![Ground-implementation-for-rush](https://user-images.githubusercontent.com/22781491/84098288-8cb31780-aa0f-11ea-8210-3122b3015c13.gif)
