### PR TITLE
Fix hold star sticking to player if the action is held too early

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableNoteSheet.cs
@@ -177,18 +177,23 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (pressCount > 1)
                 return true;
 
-            if (Head.UpdateResult(true))
+            if (!Head.AllJudged && !Head.UpdateResult(true))
+                return false;
+
+            if (Head.IsHit)
             {
                 pressCount++;
                 beginHoldAt(Time.Current - Head.HitObject.StartTime);
-                return true;
             }
 
-            return false;
+            return true;
         }
 
         private void beginHoldAt(double timeOffset)
         {
+            if (HoldStartTime != null)
+                return;
+
             if (timeOffset < -Head.HitObject.HitWindows.WindowFor(HitResult.Miss))
                 return;
 


### PR DESCRIPTION
Previously if you held down a notesheet's action before the head, it would count as breaking the notesheet but the hold star would stick to the current time.