### PR TITLE
Bump osu!lazer package to latest

### DIFF
--- a/osu.Game.Rulesets.Rush.Tests/TestSceneMiniBoss.cs
+++ b/osu.Game.Rulesets.Rush.Tests/TestSceneMiniBoss.cs
@@ -6,12 +6,11 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Rush.Beatmaps;
 using osu.Game.Rulesets.Rush.Objects;
 using osu.Game.Rulesets.Rush.UI;
-using osu.Game.Tests.Visual;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Rush.Tests
 {
-    public class TestSceneMiniBoss : PlayerTestScene
+    public class TestSceneMiniBoss : TestSceneRushPlayer
     {
         private const float mini_boss_time = 600f;
 
@@ -37,11 +36,6 @@ namespace osu.Game.Rulesets.Rush.Tests
         }
 
         private PlayerTargetLane targetLane => ((DrawableRushRuleset)Player.DrawableRuleset).Playfield.PlayerSprite.Target;
-
-        public TestSceneMiniBoss()
-            : base(new RushRuleset())
-        {
-        }
 
         [Test]
         public void TestPlayerStateTransitionsAtCorrectTime()

--- a/osu.Game.Rulesets.Rush.Tests/TestSceneRushPlayer.cs
+++ b/osu.Game.Rulesets.Rush.Tests/TestSceneRushPlayer.cs
@@ -9,9 +9,6 @@ namespace osu.Game.Rulesets.Rush.Tests
     [TestFixture]
     public class TestSceneRushPlayer : PlayerTestScene
     {
-        public TestSceneRushPlayer()
-            : base(new RushRuleset())
-        {
-        }
+        protected override Ruleset CreatePlayerRuleset() => new RushRuleset();
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                 };
             }
 
-            protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes) =>
+            protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes) =>
                 this.ScaleTo(1.5f)
                     .Then()
                     .ScaleTo(1f, timingPoint.BeatLength, Easing.Out);

--- a/osu.Game.Rulesets.Rush/UI/HitTarget.cs
+++ b/osu.Game.Rulesets.Rush/UI/HitTarget.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Rush.UI
             };
         }
 
-        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes) =>
+        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes) =>
             this.ScaleTo(1.2f)
                 .Then()
                 .ScaleTo(1f, timingPoint.BeatLength, Easing.Out);

--- a/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
+++ b/osu.Game.Rulesets.Rush/osu.Game.Rulesets.Rush.csproj
@@ -10,6 +10,6 @@
     <EmbeddedResource Include="Resources\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2020.602.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2020.710.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #38 

Can't find the exact reason (will look through tomorrow), but my guess is that this is due to confliction with JIT stuff due to us using a very old package of osu!lazer. @swoolcock assigning you to check and merge this one, and publish a new release for this. (we should probably have dependabot set up to avoid issues like these)