### PR TITLE
Actually fix sawblade leniency

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
@@ -68,13 +68,19 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (userTriggered || timeOffset < 0 || AllJudged)
                 return;
 
-            if (HitObject.HitWindows.ResultFor(timeOffset) != HitResult.None)
-                return;
+            switch (HitObject.HitWindows.ResultFor(timeOffset))
+            {
+                case HitResult.None:
+                    ApplyResult(r => r.Type = HitResult.Perfect);
+                    break;
 
-            if (playfield.PlayerSprite.CollidesWith(HitObject))
-                ApplyResult(r => r.Type = HitResult.Miss);
-            else
-                ApplyResult(r => r.Type = HitResult.Perfect);
+                case HitResult.Miss:
+                    // sawblades only hurt the player if they collide within the trailing "miss" hit window
+                    if (playfield.PlayerSprite.CollidesWith(HitObject))
+                        ApplyResult(r => r.Type = HitResult.Miss);
+
+                    break;
+            }
         }
 
         protected class Saw : CompositeDrawable

--- a/osu.Game.Rulesets.Rush/Scoring/SawbladeHitWindows.cs
+++ b/osu.Game.Rulesets.Rush/Scoring/SawbladeHitWindows.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Rush.Scoring
         protected override DifficultyRange[] GetRanges() => new[]
         {
             new DifficultyRange(HitResult.Perfect, 20, 20, 20),
-            new DifficultyRange(HitResult.Miss, 400, 400, 400)
+            new DifficultyRange(HitResult.Miss, 50, 50, 50)
         };
 
         public override bool IsHitResultAllowed(HitResult result) => result == HitResult.Perfect || result == HitResult.Miss;


### PR DESCRIPTION
Turns out the previous sawblade change actually made it *stricter*.  It's now pretty hard to actually hit a sawblade, you essentially have to just sit in the lane and not bother to jump over it at all (intended).