### PR TITLE
Move laned hit objects to nested playfields

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHitPart.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -20,6 +22,13 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             Size = new Vector2(RushPlayfield.HIT_TARGET_SIZE);
 
             Content.Add(new SkinnableDrawable(new RushSkinComponent(RushSkinComponents.DualHitPart), _ => new DualHitPartPiece()));
+        }
+
+        protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
+        {
+            base.OnDirectionChanged(e);
+
+            Anchor = LaneAnchor;
         }
 
         public new bool UpdateResult(bool userTriggered) => base.UpdateResult(userTriggered);

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
@@ -19,12 +19,12 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
     {
         public virtual Color4 LaneAccentColour => HitObject.Lane == LanedHitLane.Air ? AIR_ACCENT_COLOUR : GROUND_ACCENT_COLOUR;
 
-        public Anchor LaneAnchor =>
+        public virtual Anchor LaneAnchor =>
             HitObject.Lane switch
             {
                 LanedHitLane.Air => Direction.Value == ScrollingDirection.Left ? Anchor.TopLeft : Anchor.TopRight,
                 LanedHitLane.Ground => Direction.Value == ScrollingDirection.Left ? Anchor.BottomLeft : Anchor.BottomRight,
-                _ => Direction.Value == ScrollingDirection.Left ? Anchor.BottomLeft : Anchor.BottomRight
+                _ => Direction.Value == ScrollingDirection.Left ? Anchor.CentreLeft : Anchor.CentreRight
             };
 
         public Anchor LeadingAnchor => Direction.Value == ScrollingDirection.Left ? Anchor.CentreLeft : Anchor.CentreRight;
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         {
             base.OnDirectionChanged(e);
 
-            Anchor = LaneAnchor;
+            Anchor = LeadingAnchor;
         }
 
         public override bool OnPressed(RushAction action)

--- a/osu.Game.Rulesets.Rush/UI/HitTarget.cs
+++ b/osu.Game.Rulesets.Rush/UI/HitTarget.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Rulesets.Rush.UI
     {
         public HitTarget()
         {
+            RelativeSizeAxes = Axes.Both;
+
             Children = new Drawable[]
             {
                 new CircularContainer

--- a/osu.Game.Rulesets.Rush/UI/RushLanedPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushLanedPlayfield.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Rush.Objects;
+using osu.Game.Rulesets.UI.Scrolling;
+
+namespace osu.Game.Rulesets.Rush.UI
+{
+    public class RushLanedPlayfield : ScrollingPlayfield
+    {
+        public LanedHitLane Lane { get; }
+
+        public RushLanedPlayfield(LanedHitLane lane)
+        {
+            Lane = lane;
+            Name = $"{Lane} Playfield";
+
+            InternalChildren = new Drawable[]
+            {
+                HitObjectContainer
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
+++ b/osu.Game.Rulesets.Rush/UI/RushPlayfield.cs
@@ -36,6 +36,8 @@ namespace osu.Game.Rulesets.Rush.UI
         public const double HIT_EXPLOSION_DURATION = 200f;
 
         public RushPlayerSprite PlayerSprite { get; }
+        public RushLanedPlayfield AirPlayfield { get; }
+        public RushLanedPlayfield GroundPlayfield { get; }
 
         private readonly Container underEffectContainer;
         private readonly Container overEffectContainer;
@@ -157,7 +159,26 @@ namespace osu.Game.Rulesets.Rush.UI
                                                 Name = "Hit Objects",
                                                 RelativeSizeAxes = Axes.Both,
                                                 Padding = new MarginPadding { Left = HIT_TARGET_OFFSET },
-                                                Child = HitObjectContainer
+                                                Children = new Drawable[]
+                                                {
+                                                    HitObjectContainer,
+                                                    AirPlayfield = new RushLanedPlayfield(LanedHitLane.Air)
+                                                    {
+                                                        Anchor = Anchor.TopLeft,
+                                                        Origin = Anchor.CentreLeft,
+                                                        RelativeSizeAxes = Axes.X,
+                                                        Width = 1f,
+                                                        Height = HIT_TARGET_SIZE,
+                                                    },
+                                                    GroundPlayfield = new RushLanedPlayfield(LanedHitLane.Ground)
+                                                    {
+                                                        Anchor = Anchor.BottomLeft,
+                                                        Origin = Anchor.CentreLeft,
+                                                        RelativeSizeAxes = Axes.X,
+                                                        Width = 1f,
+                                                        Height = HIT_TARGET_SIZE,
+                                                    },
+                                                }
                                             },
                                             proxiedHitObjects = new ProxyContainer
                                             {
@@ -196,12 +217,20 @@ namespace osu.Game.Rulesets.Rush.UI
                     }
                 }
             };
+
+            AddNested(AirPlayfield);
+            AddNested(GroundPlayfield);
         }
 
         [BackgroundDependencyLoader]
         private void load(TextureStore store)
         {
         }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            AirPlayfield.ReceivePositionalInputAt(screenSpacePos) ||
+            GroundPlayfield.ReceivePositionalInputAt(screenSpacePos) ||
+            base.ReceivePositionalInputAt(screenSpacePos);
 
         public override void Add(DrawableHitObject hitObject)
         {
@@ -217,7 +246,13 @@ namespace osu.Game.Rulesets.Rush.UI
                     break;
             }
 
-            base.Add(hitObject);
+            if (hitObject is IDrawableLanedHit drawableLanedHit)
+            {
+                var playfield = drawableLanedHit.Lane == LanedHitLane.Air ? AirPlayfield : GroundPlayfield;
+                playfield.Add(hitObject);
+            }
+            else
+                base.Add(hitObject);
         }
 
         public override bool Remove(DrawableHitObject hitObject)


### PR DESCRIPTION
Required for editor.

Closes #60 