### PR TITLE
Enforce using Min/Max result types instead of arbitrary values

### DIFF
--- a/osu.Game.Rulesets.Rush/Judgements/CollisionDamagingJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Judgements/CollisionDamagingJudgement.cs
@@ -11,11 +11,12 @@ namespace osu.Game.Rulesets.Rush.Judgements
     /// </summary>
     public class CollisionDamagingJudgement : RushJudgement
     {
-        protected override double HealthPointIncreaseFor(HitResult result, bool playerCollided) =>
-            result switch
-            {
-                HitResult.Miss when playerCollided => -10.0,
-                _ => 0.0,
-            };
+        protected override double HealthPointIncreaseFor(HitResult result, bool playerCollided)
+        {
+            if (result == MinResult && playerCollided)
+                return -10.0;
+
+            return 0.0;
+        }
     }
 }

--- a/osu.Game.Rulesets.Rush/Judgements/CollisionDamagingJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Judgements/CollisionDamagingJudgement.cs
@@ -11,12 +11,7 @@ namespace osu.Game.Rulesets.Rush.Judgements
     /// </summary>
     public class CollisionDamagingJudgement : RushJudgement
     {
-        protected override double HealthPointIncreaseFor(HitResult result, bool playerCollided)
-        {
-            if (result == MinResult && playerCollided)
-                return -10.0;
-
-            return 0.0;
-        }
+        protected override double HealthPointIncreaseFor(HitResult result, bool playerCollided) =>
+            result == MinResult && playerCollided ? -10.0 : 0.0;
     }
 }

--- a/osu.Game.Rulesets.Rush/Judgements/HeartJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Judgements/HeartJudgement.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Rush.Judgements
 
         protected override double HealthPointIncreaseFor(HitResult result, bool collided)
         {
-            if (result <= HitResult.Miss && !collided)
+            if (result == MinResult && !collided)
                 return 0.0;
 
             return 50.0;

--- a/osu.Game.Rulesets.Rush/Judgements/HeartJudgement.cs
+++ b/osu.Game.Rulesets.Rush/Judgements/HeartJudgement.cs
@@ -9,12 +9,7 @@ namespace osu.Game.Rulesets.Rush.Judgements
     {
         public override HitResult MaxResult => HitResult.LargeBonus;
 
-        protected override double HealthPointIncreaseFor(HitResult result, bool collided)
-        {
-            if (result == MinResult && !collided)
-                return 0.0;
-
-            return 50.0;
-        }
+        protected override double HealthPointIncreaseFor(HitResult result, bool collided) =>
+            result == MinResult && !collided ? 0.0 : 50.0;
     }
 }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -116,11 +116,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             ApplyResult(r =>
             {
                 var lowestResult = Air.Result.Type < Ground.Result.Type ? Air.Result.Type : Ground.Result.Type;
-
-                if (!Air.IsHit && !Ground.IsHit)
-                    r.Type = r.Judgement.MinResult;
-                else
-                    r.Type = lowestResult;
+                r.Type = !Air.IsHit && !Ground.IsHit ? r.Judgement.MinResult : lowestResult;
             });
         }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableDualHit.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                 var lowestResult = Air.Result.Type < Ground.Result.Type ? Air.Result.Type : Ground.Result.Type;
 
                 if (!Air.IsHit && !Ground.IsHit)
-                    r.Type = HitResult.Miss;
+                    r.Type = r.Judgement.MinResult;
                 else
                     r.Type = lowestResult;
             });

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableHeart.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (userTriggered)
             {
                 if (result != HitResult.None)
-                    ApplyResult(r => r.Type = HitResult.LargeBonus);
+                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
 
                 return;
             }
@@ -63,11 +63,11 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
             // if we've passed the object and can longer hit it, miss
             if (result == HitResult.None)
-                ApplyResult(r => r.Type = HitResult.Miss);
+                ApplyResult(r => r.Type = r.Judgement.MinResult);
 
             // else if we're still able to hit it, check if the player is in the correct lane
             else if (playfield.PlayerSprite.CollidesWith(HitObject))
-                ApplyResult(r => r.Type = HitResult.LargeBonus);
+                ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
 
         private class HeartHitExplosion : HeartPiece

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableLanedHit.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (!userTriggered)
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                    ApplyResult(r => r.Type = HitResult.Miss);
+                    ApplyResult(r => r.Type = r.Judgement.MinResult);
                 return;
             }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (userTriggered && timeOffset < 0)
             {
                 var nextTick = ticks.FirstOrDefault(t => !t.IsHit);
-                nextTick?.TriggerResult(HitResult.SmallTickHit);
+                nextTick?.TriggerResult(nextTick.Result.Judgement.MaxResult);
 
                 var numHits = ticks.Count(r => r.IsHit);
                 var completion = (float)numHits / HitObject.RequiredHits;
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                         continue;
                     }
 
-                    tick.TriggerResult(HitResult.SmallTickMiss);
+                    tick.TriggerResult(tick.Result.Judgement.MinResult);
                 }
 
                 var hitResult = numHits == HitObject.RequiredHits

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableRushHitObject.cs
@@ -16,7 +16,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Judgements;
 using osu.Game.Rulesets.Rush.UI;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Graphics;
@@ -102,8 +101,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (timeOffset >= 0)
-                // todo: implement judgement logic
-                ApplyResult(r => r.Type = HitResult.Perfect);
+                ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
 
         public virtual bool OnPressed(RushAction action) => false;

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableSawblade.cs
@@ -62,13 +62,13 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             {
                 case HitResult.None:
                     // if we've reached the trailing "none", we successfully dodged the sawblade
-                    ApplyResult(r => r.Type = HitResult.Perfect);
+                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
                     break;
 
                 case HitResult.Miss:
                     // sawblades only hurt the player if they collide within the trailing "miss" hit window
                     if (playfield.PlayerSprite.CollidesWith(HitObject))
-                        ApplyResult(r => r.Type = HitResult.Miss);
+                        ApplyResult(r => r.Type = r.Judgement.MinResult);
 
                     break;
             }

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -143,9 +143,9 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (!Head.IsHit)
             {
                 // Head missed, judge as overall missed.
-                if (Head.Result.Type == HitResult.Miss)
+                if (Head.Result.Type == Head.Result.Judgement.MinResult)
                 {
-                    ApplyResult(r => r.Type = HitResult.Miss);
+                    ApplyResult(r => r.Type = r.Judgement.MinResult);
                     return;
                 }
 
@@ -158,7 +158,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             // Released before required progress for completion, judge as overall missed.
             if (userTriggered && Progress < REQUIRED_COMPLETION)
             {
-                ApplyResult(r => r.Type = HitResult.Miss);
+                ApplyResult(r => r.Type = r.Judgement.MinResult);
                 return;
             }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetHead.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             }
             else if (!HitObject.HitWindows.CanBeHit(timeOffset))
             {
-                ApplyResult(r => r.Type = HitResult.Miss);
+                ApplyResult(r => r.Type = r.Judgement.MinResult);
             }
         }
 

--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheetTail.cs
@@ -20,12 +20,12 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
-            var overallMissed = StarSheet.Result.Type == HitResult.Miss;
+            var overallMissed = StarSheet.Result.Type == StarSheet.Result.Judgement.MinResult;
 
             // Apply tail miss at its time when the entire star sheet has already been judged as missed.
             if (overallMissed && timeOffset >= 0)
             {
-                ApplyResult(r => r.Type = HitResult.Miss);
+                ApplyResult(r => r.Type = r.Judgement.MinResult);
                 return;
             }
 
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (!userTriggered)
             {
                 if (timeOffset >= 0)
-                    ApplyResult(r => r.Type = HitResult.Perfect);
+                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
                 return;
             }
 
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
                 return;
 
             // ...and an automatic perfect if they release within any "hit" judged period
-            ApplyResult(r => r.Type = HitResult.Perfect);
+            ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
 
         // FIXME: should logically be TrailingAnchor, not sure why it renders incorrectly


### PR DESCRIPTION
Enforces using `MinResult`/`MaxResult` instead of arbitrarily specifying a hit result value, fixes a crash when missing a heart object, due to applying result `HitResult.Miss` while the minimum hit result is `HitResult.IgnoreMiss`.

Not sure how to handle the case in `DrawableMiniBoss` though:
https://github.com/swoolcock/rush/blob/4ff68beb4599ef6067a4488778a6c0a6c1f8e11d/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableMiniBoss.cs#L126-L132 (@swoolcock @LumpBloom7 any suggestions?)