### PR TITLE
Add vscode tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Rush for osu! (Tests, Debug)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+                "${workspaceRoot}/osu.Game.Rulesets.Rush.Tests/bin/Debug/net5.0/osu.Game.Rulesets.Rush.Tests.dll"
+            ],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "Build tests (Debug)",
+            "console": "internalConsole"
+        },
+        {
+            "name": "Rush for osu! (Tests, Release)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+                "${workspaceRoot}/osu.Game.Rulesets.Rush.Tests/bin/Release/net5.0/osu.Game.Rulesets.Sentakki.Rush.dll"
+            ],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "Build tests (Release)",
+            "console": "internalConsole"
+        },
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/osu.Game.Rulesets.Rush.Tests/bin/Release/net5.0/osu.Game.Rulesets.Sentakki.Rush.dll"
+                "${workspaceRoot}/osu.Game.Rulesets.Rush.Tests/bin/Release/net5.0/osu.Game.Rulesets.Rush.Tests.dll"
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build tests (Release)",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,57 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build tests (Debug)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "osu.Game.Rulesets.Rush.Tests",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/verbosity:m"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build tests (Release)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "osu.Game.Rulesets.Rush.Tests",
+                "/p:Configuration=Release",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/verbosity:m"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        // Test Tasks
+        {
+            "label": "Run tests (Debug)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "test",
+                "/p:Configuration=Debug",
+            ],
+            "group": "test",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Run tests (Release)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "test",
+                "/p:Configuration=Release",
+            ],
+            "group": "test",
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
This PR provides some vscode specific tasks as a convenience for developers using vscode.

I copied and adapted the tasks from my own rulesets, which in turn was adapted from the main osu repo.