### PR TITLE
Respect node samples of hitobjects on beatmap conversion

### DIFF
--- a/osu.Game.Rulesets.Rush/Beatmaps/RushCraftedBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Rush/Beatmaps/RushCraftedBeatmapConverter.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Rush.Beatmaps
                         {
                             StartTime = original.StartTime,
                             EndTime = original.GetEndTime(),
-                            Samples = original.Samples,
+                            NodeSamples = (original as IHasRepeats)?.NodeSamples ?? new List<IList<HitSampleInfo>> { original.Samples },
                             Lane = LanedHitLane.Ground
                         };
                     }

--- a/osu.Game.Rulesets.Rush/Beatmaps/RushGeneratedBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Rush/Beatmaps/RushGeneratedBeatmapConverter.cs
@@ -10,7 +10,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Rush.Objects;
-using osu.Game.Rulesets.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Rush.Beatmaps

--- a/osu.Game.Rulesets.Rush/Beatmaps/RushGeneratedBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Rush/Beatmaps/RushGeneratedBeatmapConverter.cs
@@ -323,16 +323,14 @@ namespace osu.Game.Rulesets.Rush.Beatmaps
                 Samples = original.Samples
             };
 
-        private StarSheet createStarSheet(HitObject original, LanedHitLane lane, IList<HitSampleInfo> samples)
-        {
-            return new StarSheet
+        private StarSheet createStarSheet(HitObject original, LanedHitLane lane, IList<HitSampleInfo> samples) =>
+            new StarSheet
             {
                 StartTime = original.StartTime,
                 EndTime = original.GetEndTime(),
                 NodeSamples = (original as IHasRepeats)?.NodeSamples ?? new List<IList<HitSampleInfo>> { samples },
                 Lane = lane
             };
-        }
 
         private DualHit createDualHit(HitObject original) =>
             new DualHit

--- a/osu.Game.Rulesets.Rush/Beatmaps/RushGeneratedBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Rush/Beatmaps/RushGeneratedBeatmapConverter.cs
@@ -8,8 +8,9 @@ using System.Threading;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Rush.Objects;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Rush.Objects;
+using osu.Game.Rulesets.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Rush.Beatmaps
@@ -323,14 +324,16 @@ namespace osu.Game.Rulesets.Rush.Beatmaps
                 Samples = original.Samples
             };
 
-        private StarSheet createStarSheet(HitObject original, LanedHitLane lane, IList<HitSampleInfo> samples) =>
-            new StarSheet
+        private StarSheet createStarSheet(HitObject original, LanedHitLane lane, IList<HitSampleInfo> samples)
+        {
+            return new StarSheet
             {
                 StartTime = original.StartTime,
                 EndTime = original.GetEndTime(),
-                Samples = samples ?? new List<HitSampleInfo>(),
+                NodeSamples = (original as IHasRepeats)?.NodeSamples ?? new List<IList<HitSampleInfo>> { samples },
                 Lane = lane
             };
+        }
 
         private DualHit createDualHit(HitObject original) =>
             new DualHit

--- a/osu.Game.Rulesets.Rush/Objects/StarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/StarSheet.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.EntityFrameworkCore.Internal;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Types;

--- a/osu.Game.Rulesets.Rush/Objects/StarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/StarSheet.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Shane Woolcock. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.Internal;
+using osu.Game.Audio;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Rush.Judgements;
@@ -12,6 +15,8 @@ namespace osu.Game.Rulesets.Rush.Objects
 {
     public class StarSheet : LanedHit, IHasDuration
     {
+        public List<IList<HitSampleInfo>> NodeSamples;
+
         public double EndTime
         {
             get => StartTime + Duration;
@@ -68,11 +73,9 @@ namespace osu.Game.Rulesets.Rush.Objects
 
         private void updateNestedSamples()
         {
-            if (Samples.Count == 0)
-                return;
-
-            Head.Samples = Samples.Take(1).ToList();
-            Tail.Samples = Samples.TakeLast(1).ToList();
+            if (NodeSamples.Count == 0) return;
+            Head.Samples = NodeSamples.First();
+            Tail.Samples = NodeSamples.Last();
         }
 
         public override Judgement CreateJudgement() => new RushJudgement();


### PR DESCRIPTION
Resolves #112 

Previously StarSheets will use `HitObject.Samples` regardless of the original std HitObject type, causing forced StarSheets to sound different from their originals. osu!standard sliders tend to have their hitsounding stored within `IHasRepeat.NodeSamples` so that the head, tail and possibly repeats get their own hitsounds.  

I have adjusted the StarSheet to use the NodeSample list when possible, and falling back to `original.Samples` (or the parameter) when that isn't possible.

Tested with the map shown in the original issue, along with some others.