### PR TITLE
Add placeholder SR values

### DIFF
--- a/osu.Game.Rulesets.Rush/RushDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Rush/RushDifficultyCalculator.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Rush
 
         protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate)
         {
-            return new DifficultyAttributes(mods, skills, 0);
+            return new DifficultyAttributes(mods, skills, 0) { StarRating = beatmap.BeatmapInfo.StarDifficulty };
         }
 
         protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate) => Enumerable.Empty<DifficultyHitObject>();


### PR DESCRIPTION
We don't have any proper difficulty calculator, so all beatmaps are currently listed as 0 star maps and players have to guess relative difficulty. The standard SR values should give a decent enough approximation for now.

![image](https://user-images.githubusercontent.com/12001167/112751846-56f81300-8fd0-11eb-967f-3ab059e331a0.png)
