### PR TITLE
Fix star sheet bodies also being considered in acc and combo

### DIFF
--- a/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/Drawables/DrawableStarSheet.cs
@@ -7,10 +7,10 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Rush.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Rush.UI;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
@@ -170,9 +170,7 @@ namespace osu.Game.Rulesets.Rush.Objects.Drawables
             if (!Tail.Judged)
                 return;
 
-            // Determine the overall judgement for the object when the tail is judged.
-            var minimumResult = (HitResult)Math.Min((int)Head.Result.Type, (int)Tail.Result.Type);
-            ApplyResult(r => r.Type = minimumResult);
+            ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
 
         public override bool OnPressed(RushAction action)

--- a/osu.Game.Rulesets.Rush/Objects/StarSheet.cs
+++ b/osu.Game.Rulesets.Rush/Objects/StarSheet.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Rush.Objects
             Tail.Samples = NodeSamples.Last();
         }
 
-        public override Judgement CreateJudgement() => new RushJudgement();
+        public override Judgement CreateJudgement() => new RushIgnoreJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
     }


### PR DESCRIPTION
Previously star sheets provided 3 combos, one at the start, and two at the end. The judgement it gives is also the minimum between the two, causing overlap.

